### PR TITLE
Reduce sidebar width and add yellow bottom shadow to cards

### DIFF
--- a/client/components/ui/sidebar.tsx
+++ b/client/components/ui/sidebar.tsx
@@ -19,8 +19,8 @@ import {
 
 const SIDEBAR_COOKIE_NAME = "sidebar:state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
-const SIDEBAR_WIDTH = "16rem";
-const SIDEBAR_WIDTH_MOBILE = "18rem";
+const SIDEBAR_WIDTH = "12rem";
+const SIDEBAR_WIDTH_MOBILE = "14rem";
 const SIDEBAR_WIDTH_ICON = "3rem";
 const SIDEBAR_KEYBOARD_SHORTCUT = "b";
 

--- a/client/global.css
+++ b/client/global.css
@@ -187,24 +187,38 @@
   position: relative;
   border-radius: var(--radius);
 }
+/* Top cover to eliminate any visible top shadow completely */
+.card-yellow-shadow::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 22px; /* cover top edge fully */
+  background: hsl(var(--card) / 0.60); /* match bg-card/60 */
+  border-top-left-radius: var(--radius);
+  border-top-right-radius: var(--radius);
+  pointer-events: none;
+  z-index: 1;
+}
 .card-yellow-shadow::after {
   content: "";
   position: absolute;
   left: 0;
   right: 0;
-  top: 8px;          /* start below top to avoid any top spill */
-  bottom: -8px;      /* extend a bit to enhance bottom drop */
+  top: 14px;         /* start lower to avoid top */
+  bottom: -10px;     /* extend for bottom drop */
   pointer-events: none;
   border-radius: inherit;
   box-shadow:
-    -8px 0 22px hsl(var(--secondary) / 0.45),  /* left */
-    8px 0 22px hsl(var(--secondary) / 0.45),   /* right */
-    0 24px 48px hsl(var(--secondary) / 0.60);  /* bottom */
+    -8px 0 18px hsl(var(--secondary) / 0.28),  /* left (softer) */
+    8px 0 18px hsl(var(--secondary) / 0.28),   /* right (softer) */
+    0 22px 42px hsl(var(--secondary) / 0.40);  /* bottom (softer) */
 }
 .card-yellow-shadow:hover::after {
   box-shadow:
-    -10px 0 26px hsl(var(--secondary) / 0.55),
-    10px 0 26px hsl(var(--secondary) / 0.55),
-    0 28px 56px hsl(var(--secondary) / 0.68);
+    -9px 0 20px hsl(var(--secondary) / 0.35),
+    9px 0 20px hsl(var(--secondary) / 0.35),
+    0 24px 46px hsl(var(--secondary) / 0.48);
   transition: box-shadow 0.2s ease-in-out;
 }

--- a/client/global.css
+++ b/client/global.css
@@ -184,11 +184,25 @@
 
 /* Yellow side and bottom shadow for cards */
 .card-yellow-shadow {
+  position: relative;
   box-shadow:
     -6px 0 18px hsl(var(--secondary) / 0.35), /* left */
     6px 0 18px hsl(var(--secondary) / 0.35),  /* right */
     0 10px 22px hsl(var(--secondary) / 0.45); /* bottom */
   border-radius: var(--radius);
+}
+/* Mask any residual top glow */
+.card-yellow-shadow::before {
+  content: "";
+  position: absolute;
+  top: -8px;
+  left: 0;
+  right: 0;
+  height: 8px;
+  background: hsl(var(--background));
+  pointer-events: none;
+  border-top-left-radius: var(--radius);
+  border-top-right-radius: var(--radius);
 }
 .card-yellow-shadow:hover {
   box-shadow:

--- a/client/global.css
+++ b/client/global.css
@@ -188,7 +188,7 @@
   box-shadow:
     -6px 0 18px hsl(var(--secondary) / 0.35), /* left */
     6px 0 18px hsl(var(--secondary) / 0.35),  /* right */
-    0 10px 22px hsl(var(--secondary) / 0.45); /* bottom */
+    0 18px 36px hsl(var(--secondary) / 0.50); /* bottom */
   border-radius: var(--radius);
 }
 /* Mask any residual top glow */
@@ -208,6 +208,6 @@
   box-shadow:
     -8px 0 22px hsl(var(--secondary) / 0.45),
     8px 0 22px hsl(var(--secondary) / 0.45),
-    0 14px 28px hsl(var(--secondary) / 0.55);
+    0 24px 48px hsl(var(--secondary) / 0.60);
   transition: box-shadow 0.2s ease-in-out;
 }

--- a/client/global.css
+++ b/client/global.css
@@ -215,10 +215,3 @@
     8px 0 18px hsl(var(--secondary) / 0.28),   /* right (softer) */
     0 22px 42px hsl(var(--secondary) / 0.40);  /* bottom (softer) */
 }
-.card-yellow-shadow:hover::after {
-  box-shadow:
-    -9px 0 20px hsl(var(--secondary) / 0.35),
-    9px 0 20px hsl(var(--secondary) / 0.35),
-    0 24px 46px hsl(var(--secondary) / 0.48);
-  transition: box-shadow 0.2s ease-in-out;
-}

--- a/client/global.css
+++ b/client/global.css
@@ -182,32 +182,29 @@
   }
 }
 
-/* Yellow side and bottom shadow for cards */
+/* Yellow side and bottom shadow for cards (no top glow) */
 .card-yellow-shadow {
   position: relative;
-  box-shadow:
-    -6px 0 18px hsl(var(--secondary) / 0.35), /* left */
-    6px 0 18px hsl(var(--secondary) / 0.35),  /* right */
-    0 18px 36px hsl(var(--secondary) / 0.50); /* bottom */
   border-radius: var(--radius);
 }
-/* Mask any residual top glow */
-.card-yellow-shadow::before {
+.card-yellow-shadow::after {
   content: "";
   position: absolute;
-  top: -8px;
   left: 0;
   right: 0;
-  height: 8px;
-  background: hsl(var(--background));
+  top: 8px;          /* start below top to avoid any top spill */
+  bottom: -8px;      /* extend a bit to enhance bottom drop */
   pointer-events: none;
-  border-top-left-radius: var(--radius);
-  border-top-right-radius: var(--radius);
-}
-.card-yellow-shadow:hover {
+  border-radius: inherit;
   box-shadow:
-    -8px 0 22px hsl(var(--secondary) / 0.45),
-    8px 0 22px hsl(var(--secondary) / 0.45),
-    0 24px 48px hsl(var(--secondary) / 0.60);
+    -8px 0 22px hsl(var(--secondary) / 0.45),  /* left */
+    8px 0 22px hsl(var(--secondary) / 0.45),   /* right */
+    0 24px 48px hsl(var(--secondary) / 0.60);  /* bottom */
+}
+.card-yellow-shadow:hover::after {
+  box-shadow:
+    -10px 0 26px hsl(var(--secondary) / 0.55),
+    10px 0 26px hsl(var(--secondary) / 0.55),
+    0 28px 56px hsl(var(--secondary) / 0.68);
   transition: box-shadow 0.2s ease-in-out;
 }

--- a/client/global.css
+++ b/client/global.css
@@ -181,3 +181,19 @@
     height: 0;
   }
 }
+
+/* Yellow side and bottom shadow for cards */
+.card-yellow-shadow {
+  box-shadow:
+    -6px 0 18px hsl(var(--secondary) / 0.35), /* left */
+    6px 0 18px hsl(var(--secondary) / 0.35),  /* right */
+    0 10px 22px hsl(var(--secondary) / 0.45); /* bottom */
+  border-radius: var(--radius);
+}
+.card-yellow-shadow:hover {
+  box-shadow:
+    -8px 0 22px hsl(var(--secondary) / 0.45),
+    8px 0 22px hsl(var(--secondary) / 0.45),
+    0 14px 28px hsl(var(--secondary) / 0.55);
+  transition: box-shadow 0.2s ease-in-out;
+}

--- a/client/global.css
+++ b/client/global.css
@@ -206,12 +206,12 @@
   position: absolute;
   left: 0;
   right: 0;
-  top: 14px;         /* start lower to avoid top */
-  bottom: -10px;     /* extend for bottom drop */
+  top: 16px;         /* start below top to avoid any top glow */
+  bottom: -24px;     /* increase bottom extension for taller drop */
   pointer-events: none;
   border-radius: inherit;
+  /* Bottom-only yellow shadow */
   box-shadow:
-    -8px 0 18px hsl(var(--secondary) / 0.28),  /* left (softer) */
-    8px 0 18px hsl(var(--secondary) / 0.28),   /* right (softer) */
-    0 22px 42px hsl(var(--secondary) / 0.40);  /* bottom (softer) */
+    0 36px 64px hsl(var(--secondary) / 0.38),  /* main bottom */
+    0 16px 28px hsl(var(--secondary) / 0.24);  /* soft inner */
 }

--- a/client/global.css
+++ b/client/global.css
@@ -195,7 +195,7 @@
   left: 0;
   right: 0;
   height: 22px; /* cover top edge fully */
-  background: hsl(var(--card) / 0.60); /* match bg-card/60 */
+  background: hsl(var(--card) / 0.6); /* match bg-card/60 */
   border-top-left-radius: var(--radius);
   border-top-right-radius: var(--radius);
   pointer-events: none;
@@ -206,12 +206,12 @@
   position: absolute;
   left: 0;
   right: 0;
-  top: 16px;         /* start below top to avoid any top glow */
-  bottom: -24px;     /* increase bottom extension for taller drop */
+  top: 16px; /* start below top to avoid any top glow */
+  bottom: -24px; /* increase bottom extension for taller drop */
   pointer-events: none;
   border-radius: inherit;
   /* Bottom-only yellow shadow */
   box-shadow:
-    0 36px 64px hsl(var(--secondary) / 0.38),  /* main bottom */
-    0 16px 28px hsl(var(--secondary) / 0.24);  /* soft inner */
+    0 36px 64px hsl(var(--secondary) / 0.38),
+    /* main bottom */ 0 16px 28px hsl(var(--secondary) / 0.24); /* soft inner */
 }

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -114,7 +114,7 @@ function ExternalPdfSelector({
   };
 
   return (
-    <div className="rounded-md border border-muted/20 bg-card/60 p-4">
+    <div className="rounded-md card-yellow-shadow border border-muted/20 bg-card/60 p-4">
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 items-end">
         <div>
           <label className="text-xs text-muted-foreground">Class</label>
@@ -728,7 +728,7 @@ export default function Index() {
                 </div>
               </div>
 
-              <div className="mt-3 rounded-md bg-card/60 p-6 text-base">
+              <div className="mt-3 rounded-md card-yellow-shadow bg-card/60 p-6 text-base">
                 <div
                   className="prose prose-invert prose-lg leading-relaxed max-w-none"
                   dangerouslySetInnerHTML={{

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -171,7 +171,7 @@ function ExternalPdfSelector({
             type="number"
             min={20}
             max={100}
-            step={1}
+            step="any"
             value={totalMarks ?? ""}
             placeholder="Enter"
             onChange={(e) => {
@@ -182,15 +182,14 @@ function ExternalPdfSelector({
               }
               const n = Number(val);
               if (isNaN(n)) return;
-              const clamped = Math.min(100, Math.max(20, Math.floor(n)));
-              setTotalMarks(clamped);
+              setTotalMarks(n);
             }}
             onBlur={(e) => {
               const val = e.target.value;
               if (val === "") return;
               const n = Number(val);
               if (isNaN(n)) return;
-              const clamped = Math.min(100, Math.max(20, Math.floor(n)));
+              const clamped = Math.min(100, Math.max(20, n));
               if (clamped !== n) setTotalMarks(clamped);
             }}
             className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none"
@@ -222,10 +221,13 @@ function ExternalPdfSelector({
                 description: "Please enter a value between 20 and 100.",
               });
             }
+            // Clamp marks just before generating
+            const marks = Math.min(100, Math.max(20, Number(totalMarks)));
+            if (marks !== totalMarks) setTotalMarks(marks);
             const generated = buildPaperSchemePrompt(
               subjectName,
               selectedClass || "",
-              totalMarks,
+              marks,
             );
             onSetPrompt(generated);
             await onGenerate(generated);

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -245,10 +245,14 @@ function ExternalPdfSelector({
         <button
           disabled={loading}
           onClick={() => {
-            // clear selection
+            // clear local selections
+            setSelectedClass("");
             setSelectedSubjectPath("");
-            // clear parent file state
+            setTotalMarks(null);
+            setPromptText("");
+            // clear parent state
             onLoadFile(null);
+            onSetPrompt("");
             onReset();
           }}
           className="rounded-md bg-muted/40 px-3 py-2 text-sm disabled:opacity-60 disabled:cursor-not-allowed"

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -167,36 +167,37 @@ function ExternalPdfSelector({
           className={`transition-opacity ${!selectedClass ? "opacity-50 pointer-events-none" : ""}`}
         >
           <label className="text-xs text-muted-foreground">Total Marks</label>
-          <input
-            type="number"
-            min={20}
-            max={100}
-            step="any"
-            value={totalMarks ?? ""}
-            placeholder="Enter"
-            onChange={(e) => {
-              const val = e.target.value;
-              if (val === "") {
-                setTotalMarks(null);
-                return;
-              }
-              const n = Number(val);
-              if (isNaN(n)) return;
-              setTotalMarks(n);
-            }}
-            onBlur={(e) => {
-              const val = e.target.value;
-              if (val === "") return;
-              const n = Number(val);
-              if (isNaN(n)) return;
-              const clamped = Math.min(100, Math.max(20, n));
-              if (clamped !== n) setTotalMarks(clamped);
-            }}
-            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none"
-            disabled={!selectedClass}
-          />
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => setTotalMarks(30)}
+              disabled={!selectedClass || !!loading}
+              aria-pressed={totalMarks === 30}
+              className={`rounded-md px-3 py-2 text-sm border ${totalMarks === 30 ? "bg-secondary text-secondary-foreground border-secondary" : "bg-muted/40 text-foreground/90 border-input hover:bg-muted/60"}`}
+            >
+              30
+            </button>
+            <button
+              type="button"
+              onClick={() => setTotalMarks(50)}
+              disabled={!selectedClass || !!loading}
+              aria-pressed={totalMarks === 50}
+              className={`rounded-md px-3 py-2 text-sm border ${totalMarks === 50 ? "bg-secondary text-secondary-foreground border-secondary" : "bg-muted/40 text-foreground/90 border-input hover:bg-muted/60"}`}
+            >
+              50
+            </button>
+            <button
+              type="button"
+              onClick={() => setTotalMarks(100)}
+              disabled={!selectedClass || !!loading}
+              aria-pressed={totalMarks === 100}
+              className={`rounded-md px-3 py-2 text-sm border ${totalMarks === 100 ? "bg-secondary text-secondary-foreground border-secondary" : "bg-muted/40 text-foreground/90 border-input hover:bg-muted/60"}`}
+            >
+              100
+            </button>
+          </div>
           <p className="text-xs text-muted-foreground mt-1">
-            Enter marks between 20 and 100
+            Select 30, 50, or 100
           </p>
         </div>
       </div>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -216,6 +216,12 @@ function ExternalPdfSelector({
             const subjectName = found
               ? found.name.replace(/\.pdf$/i, "")
               : selectedSubjectPath || "";
+            if (totalMarks == null) {
+              return toast({
+                title: "Enter total marks",
+                description: "Please enter a value between 20 and 100.",
+              });
+            }
             const generated = buildPaperSchemePrompt(
               subjectName,
               selectedClass || "",

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -615,16 +615,18 @@ export default function Index() {
           )}
 
           {/* External controls: Class -> Subject -> Prompt */}
-          <ExternalPdfSelector
-            onLoadFile={(f) => setFile(f)}
-            onSetPrompt={(p) => setQuery(p)}
-            onGenerate={async (p?: string) => await runSubmit(undefined, p)}
-            onReset={onReset}
-            loading={loading}
-          />
+          <div className="w-full max-w-2xl ml-auto">
+            <ExternalPdfSelector
+              onLoadFile={(f) => setFile(f)}
+              onSetPrompt={(p) => setQuery(p)}
+              onGenerate={async (p?: string) => await runSubmit(undefined, p)}
+              onReset={onReset}
+              loading={loading}
+            />
+          </div>
 
           {result && (
-            <div className="mt-4">
+            <div className="mt-4 w-full max-w-2xl ml-auto">
               <div className="flex items-center justify-between">
                 <h3 className="text-sm font-semibold">Result</h3>
                 <div className="flex items-center gap-2">

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -171,6 +171,7 @@ function ExternalPdfSelector({
             type="number"
             min={20}
             max={100}
+            step={1}
             value={totalMarks ?? ""}
             placeholder="Enter"
             onChange={(e) => {
@@ -183,6 +184,14 @@ function ExternalPdfSelector({
               if (isNaN(n)) return;
               const clamped = Math.min(100, Math.max(20, Math.floor(n)));
               setTotalMarks(clamped);
+            }}
+            onBlur={(e) => {
+              const val = e.target.value;
+              if (val === "") return;
+              const n = Number(val);
+              if (isNaN(n)) return;
+              const clamped = Math.min(100, Math.max(20, Math.floor(n)));
+              if (clamped !== n) setTotalMarks(clamped);
             }}
             className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none"
             disabled={!selectedClass}

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -615,7 +615,7 @@ export default function Index() {
           )}
 
           {/* External controls: Class -> Subject -> Prompt */}
-          <div className="w-full max-w-2xl ml-auto">
+          <div className="w-full max-w-2xl mx-auto">
             <ExternalPdfSelector
               onLoadFile={(f) => setFile(f)}
               onSetPrompt={(p) => setQuery(p)}
@@ -626,7 +626,7 @@ export default function Index() {
           </div>
 
           {result && (
-            <div className="mt-4 w-full max-w-2xl ml-auto">
+            <div className="mt-4 w-full max-w-2xl mx-auto">
               <div className="flex items-center justify-between">
                 <h3 className="text-sm font-semibold">Result</h3>
                 <div className="flex items-center gap-2">


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses several UI layout and styling requests:
- Reduce sidebar width to provide more space for the main content area
- Add yellow shadow effects to cards with specific requirements: remove top shadows completely, keep left/right/bottom shadows, and increase bottom shadow height for better visual emphasis
- Center-align cards with equal spacing on left and right sides
- Replace total marks input field with button selection for better UX

## Code Changes

**Sidebar Width Reduction:**
- Reduced desktop sidebar width from 16rem to 12rem
- Reduced mobile sidebar width from 18rem to 14rem

**Card Shadow Styling:**
- Added new `.card-yellow-shadow` CSS class with yellow bottom-focused shadows
- Implemented top shadow elimination using a pseudo-element overlay
- Applied increased bottom shadow height (36px + 16px) with yellow secondary color
- Applied shadow styling to ExternalPdfSelector and result display cards

**Layout Improvements:**
- Center-aligned cards using `max-w-2xl mx-auto` for consistent spacing
- Replaced total marks number input with three preset buttons (30, 50, 100)
- Enhanced form validation and state management for better user experienceTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 7`

🔗 [Edit in Builder.io](https://builder.io/app/projects/975b69356ef54768ac5048d9902dd044/orbit-haven)

👀 [Preview Link](https://975b69356ef54768ac5048d9902dd044-orbit-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>975b69356ef54768ac5048d9902dd044</projectId>-->
<!--<branchName>orbit-haven</branchName>-->