### PR TITLE
Add institute name input and adjust result card width

### DIFF
--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -722,7 +722,7 @@ export default function Index() {
           </div>
 
           {result && (
-            <div className="order-1 mt-0 w-full max-w-3xl mx-auto">
+            <div className="order-1 mt-0 w-full max-w-5xl mx-auto">
               <div className="flex items-center justify-between">
                 <h3 className="text-sm font-semibold">Result</h3>
                 <div className="flex items-center gap-2">

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -722,7 +722,7 @@ export default function Index() {
           </div>
 
           {result && (
-            <div className="order-1 mt-0 w-full max-w-5xl mx-auto">
+            <div className="order-1 mt-0 w-full max-w-3xl mx-auto">
               <div className="flex items-center justify-between">
                 <h3 className="text-sm font-semibold">Result</h3>
                 <div className="flex items-center gap-2">

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -722,7 +722,7 @@ export default function Index() {
           </div>
 
           {result && (
-            <div className="order-1 mt-0 w-full max-w-5xl mx-auto">
+            <div className="order-1 mt-0 w-full max-w-4xl mx-auto">
               <div className="flex items-center justify-between">
                 <h3 className="text-sm font-semibold">Result</h3>
                 <div className="flex items-center gap-2">

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -279,7 +279,9 @@ function ExternalPdfSelector({
         </div>
 
         <div>
-          <label className="text-xs text-muted-foreground">Institute Name</label>
+          <label className="text-xs text-muted-foreground">
+            Institute Name
+          </label>
           <input
             type="text"
             value={instituteName}
@@ -811,8 +813,14 @@ export default function Index() {
                         // Cover/header
                         doc.setFont("times", "bold");
                         doc.setFontSize(22);
-                        const headingTitle = (institute && institute.trim()) ? institute.trim() : "Test Paper Generater";
-                        const headerLines = doc.splitTextToSize(headingTitle, pageW - margin * 2);
+                        const headingTitle =
+                          institute && institute.trim()
+                            ? institute.trim()
+                            : "Test Paper Generater";
+                        const headerLines = doc.splitTextToSize(
+                          headingTitle,
+                          pageW - margin * 2,
+                        );
                         doc.text(headerLines, pageW / 2, y, {
                           align: "center",
                         });
@@ -1029,12 +1037,9 @@ export default function Index() {
                           doc.setFont("times", "bold");
                           doc.setFontSize(12);
                           doc.setTextColor(200);
-                          doc.text(
-                            headingTitle,
-                            pageW / 2,
-                            pageH - 28,
-                            { align: "center" },
-                          );
+                          doc.text(headingTitle, pageW / 2, pageH - 28, {
+                            align: "center",
+                          });
                           doc.setTextColor(0);
                         }
 


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses two main requests:
1. Reduce the width of the result card to match the chat card width
2. Add an institute name input option that allows users to customize the PDF header instead of the default "Test Paper Generater" text

## Code changes

- **Institute Name Input**: Added a new text input field for institute name with proper state management (`instituteName`, `onSetInstitute`)
- **PDF Header Customization**: Modified PDF generation to use the institute name as the header title when provided, falling back to "Test Paper Generater" when empty
- **Result Card Width**: Changed result card container from `max-w-5xl` to `max-w-4xl` to reduce width
- **State Management**: Added institute state tracking and proper cleanup on reset
- **Dynamic Text Handling**: Implemented text wrapping for longer institute names in PDF headersTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 12`

🔗 [Edit in Builder.io](https://builder.io/app/projects/4fc02fc543184099984c2884bcc96ab5/glow-zone)

👀 [Preview Link](https://4fc02fc543184099984c2884bcc96ab5-glow-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>4fc02fc543184099984c2884bcc96ab5</projectId>-->
<!--<branchName>glow-zone</branchName>-->